### PR TITLE
Deprecated `quilt.mod.json`

### DIFF
--- a/quilt/src/main/resources/quilt.mod.json
+++ b/quilt/src/main/resources/quilt.mod.json
@@ -1,21 +1,20 @@
 {
   "schema_version": 1,
-  "mixin": [
-    "devlogin.mixins.json"
-  ],
   "quilt_loader": {
     "group": "${group}",
     "id": "devlogin",
     "version": "${version}",
-    "name": "DevLogin",
-    "description": "A simple mod that allows developers to login with their own Minecraft account in a mod development environment.",
-    "authors": [
-      "PlanetTeamSpeak"
-    ],
-    "contact": {
-      "sources": "https://github.com/PlanetTeamSpeakk/DevLogin"
+    "metadata": {
+      "name": "DevLogin",
+      "description": "A simple mod that allows developers to login with their own Minecraft account in a mod development environment.",
+      "authors": [
+        "PlanetTeamSpeak"
+      ],
+      "contact": {
+        "sources": "https://github.com/PlanetTeamSpeakk/DevLogin"
+      },
+      "license": "MIT"
     },
-    "license": "MIT",
     "intermediate_mappings": "net.fabricmc:intermediary",
     "environment": "client",
     "depends": [
@@ -27,6 +26,9 @@
         "id": "minecraft",
         "version": "*"
       }
+    ],
+    "mixin": [
+      "devlogin.mixins.json"
     ]
   }
 }


### PR DESCRIPTION
The mod metadatas were in the global object of the quilt.mod.json but are supposed to be in a subobject of key `metadata`.

Here's the [RFC definition](https://github.com/QuiltMC/rfcs/blob/main/specification/0002-quilt.mod.json.md#the-metadata-field).

This PR changes exactly that for this extension to be used with Quilt.